### PR TITLE
Add entries to `ocsp.txt` 

### DIFF
--- a/hosts/blacklist/fakenews.txt
+++ b/hosts/blacklist/fakenews.txt
@@ -5,3 +5,4 @@ rkrgbbyftbbqvrf.ubzr.oybt
 rkrgbbyftbbqvrfubzr.jbeqcerff.pbz
 rkrgbbyftbbqvrfubzr.svyrf.jbeqcerff.pbz
 rkrgbbyf.yvir
+rkrgbbyf.pyho

--- a/script/blacklist.conf
+++ b/script/blacklist.conf
@@ -19,8 +19,8 @@
 file:..\hosts\blacklist\activation.txt
 file:..\hosts\blacklist\ads.txt
 file:..\hosts\blacklist\anticheat.txt
-file:..\hosts\blacklist\miscellaneous.txt
-file:..\hosts\blacklist\telemetry.txt
+file:..\hosts\blacklist\misc.txt
+file:..\hosts\blacklist\tracking.txt
 obfus file:..\hosts\blacklist\fakenews.txt
 
 # 🐧ペンギン🐣's list to block tracking, advertising, profiling and unnecessary stuff in games, programs and (complete) websites.


### PR DESCRIPTION
@zeffy Here's two more certification revoke domains that Apple devices use, [[source]](https://support.apple.com/en-us/HT210060).

The first domain has also been referred to in this repo: https://github.com/anudeepND/whitelist/issues/36